### PR TITLE
[Fix] 이벤트 어드민 QA 수정사항 반영

### DIFF
--- a/src/components/layouts/AdminMenuBar.jsx
+++ b/src/components/layouts/AdminMenuBar.jsx
@@ -14,6 +14,7 @@ const AdminMenuBar = ({ className, nav, closeMenu, adminMenuRef, showLogoutPopup
     localStorage.removeItem('accessToken');
     setIsLoggedIn(false);
     nav('/admin');
+    nav(0);
   };
 
   const handleConfirmLogout = () => {


### PR DESCRIPTION
## 🌟 어떤 이유로 MR를 하셨나요?

- [ ] feature 병합()
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [x] 코드 개선
- [x] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 📝 세부 내용 - 왜 해당 MR이 필요한지 작업 내용을 자세하게 설명해주세요

- 당첨 취소 시 더보기 화면이 사라지지 않게 유지하였습니다.
- 패딩값을 추가하여 데이터가 많아져도 스크롤 가능하게 하였습니다.
- 로그아웃 버튼 클릭 후 바로 헤더가 삭제되도록 하였습니다.

## 📸 작업 화면 스크린샷

1. 스크롤 가능하게 
<img width="374" alt="스크린샷 2024-09-15 오후 11 09 43" src="https://github.com/user-attachments/assets/d33b5192-d2f7-43f1-8ca9-037edf83258d">

2. 당첨 취소 시
<img width="351" alt="스크린샷 2024-09-15 오후 11 10 03" src="https://github.com/user-attachments/assets/cf86cff9-b9b3-4563-8582-4d6edcae26cf">

취소자만 색 업데이트 후 목록 유지
<img width="373" alt="스크린샷 2024-09-15 오후 11 10 09" src="https://github.com/user-attachments/assets/a30d7278-a2f4-4d97-99a3-6a54d8846e73">


## ⚠️ MR하기 전에 확인해주세요

- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## 📢 로컬 실행 시 유의사항
-  

<!-- 이슈는 해당사항 있는 사람만 주석 해제하고 사용하시면 됩니다.
-- ## 🚨 관련 이슈 번호

 - #70 -->
