### PR TITLE
[Fix] main Lottie 애니메이션 safari 크기 이슈 해결

### DIFF
--- a/src/pages/main/MainPage.styled.js
+++ b/src/pages/main/MainPage.styled.js
@@ -1,5 +1,6 @@
-import { styled, css, keyframes } from 'styled-components';
+import { styled } from 'styled-components';
 import arrow from '@/assets/webps/main/arrowRight.webp';
+import Lottie from 'lottie-react';
 
 export const Container = styled.div`
   display: flex;
@@ -21,7 +22,6 @@ export const Wrapper = styled.div`
 export const LottieWrapper = styled.div`
   position: absolute;
   top: 0;
-  display: flex;
   width: 37.5rem;
   height: 70.7rem;
 `;


### PR DESCRIPTION
## 🌟 어떤 이유로 MR를 하셨나요?

- [ ] feature 병합
- [x] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [ ] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 📝 세부 내용 - 왜 해당 MR이 필요한지 작업 내용을 자세하게 설명해주세요

- display: flex; 삭제하여 데스크톱 safari에서 로티 애니메이션 작게 보이는 이슈 해결하였습니다.

## 📸 작업 화면 스크린샷

https://github.com/user-attachments/assets/df109ed2-ce34-4112-aba6-894513e95c6a


## ⚠️ MR하기 전에 확인해주세요

- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## 📢 로컬 실행 시 유의사항
